### PR TITLE
configure pylint as static analyzer, remove support of python2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,7 @@ language: python
 
 install:
   - make venv
-  - make venv3
 
 script:
   - make lint
   - make tests
-  - make lint3
-  - make tests3

--- a/Makefile
+++ b/Makefile
@@ -5,33 +5,17 @@ help: ## provides cli help for this make file (default)
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: lint
-lint: ## provides cli help for this make file (default) for python 2
+lint: ## provides cli help for this make file (default) for python 3
 	@. venv/bin/activate; pylint --rcfile=.pylintrc spike_starter
 
-.PHONY: lint3
-lint3: ## provides cli help for this make file (default) for python 3
-	@. venv3/bin/activate; pylint --rcfile=.pylintrc spike_starter
-
 .PHONY: tests
-tests: tests_integrations ## run all validation tests for python 2
-
-.PHONY: tests3
-tests3: tests_integrations3 ## run all validation tests for python 3
+tests: tests_integrations ## run all validation tests for python 3
 
 .PHONY: tests_integrations
 tests_integrations: ## run integrations tests
 	@. venv/bin/activate; python -u -m unittest discover ${args} spike_starter_tests/integrations
 
-.PHONY: tests_integrations3
-tests_integrations3: ## run integrations tests
-	@. venv3/bin/activate; python -u -m unittest discover ${args} spike_starter_tests/integrations
-
 .PHONY: venv
-venv: ## generate python 2.7 virtualenv in venv directory
-	virtualenv venv
+venv: ## generate python 3 virtualenv in venv directory
+	virtualenv -p python3 venv
 	@. venv/bin/activate; pip install -e.[dev]
-
-.PHONY: venv3
-venv3: ## generate python 3 virtualenv in venv directory
-	virtualenv -p /usr/bin/python3 venv3
-	@. venv3/bin/activate; pip install -e.[dev]

--- a/README.md
+++ b/README.md
@@ -48,5 +48,6 @@ pip install .
 A pull request on Spike starter should pass the automatic tests.
 
 ```bash
+make lint
 make tests
 ```

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
   name='spike_starter',
-  version='0.0.5',
+  version='0.0.6',
   packages=find_packages(exclude=["*_tests"]),
   license='',
   long_description=open('README.md').read(),
@@ -12,7 +12,6 @@ setup(
     'Environment :: Console',
     'Intended Audience :: Developers',
     'Intended Audience :: System Administrators',
-    'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 3'
   ],
   entry_points={
@@ -22,12 +21,12 @@ setup(
   },
   install_requires=[
     'click',
-    'GitPython',
-    'future'
+    'GitPython'
   ],
   extras_require={
-      'dev': [
-          'pylint'
-      ]
+    'dev': [
+      'pylint',
+      'tox'
+    ]
   }
 )

--- a/spike_starter/__main__.py
+++ b/spike_starter/__main__.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python
 
-from __future__ import print_function
-from builtins import object
 import getopt
 import logging
 import os
@@ -60,7 +58,7 @@ def usage():
   print("python %s (-h) [-t template_path] projects" % (sys.argv[0]))
 
 
-class SpikeStarter(object):
+class SpikeStarter:
 
   def __init__(self):
     pass


### PR DESCRIPTION
* ensure spike-starter is compliant with the set of rules available in .pylintrc
* remove support of python2 that will be obsolete in jan 2020
* add lint step  as validation step